### PR TITLE
Use Github actions to build and deploy documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,35 @@
+name: Build docs
+
+on:
+  push:
+    branches:
+        - main
+  pull_request:
+    branches:
+        - main
+  workflow_dispatch:
+
+jobs:
+  build-docs:
+    permissions: 
+        contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.12
+      - name: Install dependencies 🛠️
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-docs.txt
+      - name: Build docs 📖
+        run: mkdocs build
+      - name: Deploy docs 🚀
+        if: ${{ github.event_name == 'push' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: site
+

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,7 +7,7 @@ Depends on:
 ---
 
 1. Clone the repository and create and activate a python virtual environment of your choice.
-1. Inside a virtual environment or machine: `python -m pip install -r requirements-docs.txt`
+1. Inside a virtual environment or machine: `python -m pip install -r requirements.txt`
 
 ## Release/Versioning
 
@@ -15,6 +15,7 @@ Version numbers should be used in tagging commits on the `main` branch and shoul
 
 ## Building & deploying the documentation
 
-Run `mkdocs build` to build the docs.
+The documentation should build automatically on pushes to `main` using GitHub actions, if you want to build and deploy the docs manually, follow these steps:
 
-Then run `mkdocs gh-deploy` to deploy to the `gh-pages` branch of the repository. You must have write access to the repo.
+* Run `make build-docs` to build the docs to the `./site` directory.
+* Then run `make deploy-docs` to deploy to the `gh-pages` branch of the repository. You must have write access to the repo.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,10 +1,3 @@
-polar-route==1.0.0
-cdsapi
-copernicusmarine==2.0.0
-bas-geoplot
-sap @ git+https://github.com/antarctica/simple-action-pipeline@main
-py-meshiphi-geojson2png @ git+https://github.com/matscorse/py-meshiphi-geojson2png.git
-
 mkdocs
 mkdocs-include-markdown-plugin
 mkdocstrings[python]


### PR DESCRIPTION
* add gha workflow to build/deploy docs similarly to PolarRoute-server
* remove main deps from docs requirements
* update dev docs