### PR TITLE
Allow greater range of copernicus marine authentication options

### DIFF
--- a/docs/setting-up.md
+++ b/docs/setting-up.md
@@ -41,11 +41,13 @@ echo verify:0 >> $HOME/.cdsapirc
 
 ### Copernicus Marine API
 The Copernicus API to is used to download up-to-date DUACS currents data. This service requires obtaining a USERNAME and PASSWORD for logging in. Once you have the username and password they can be stored separately to the pipeline in the user's `HOME` directory. You can register on the [Copernicus Marine API Registration](https://data.marine.copernicus.eu/register) page. Then, use the `copernicusmarine` command line tool to log in and set up your credentials file. First make sure that your python virtual environment is activated and you have installed the dependencies. Then:
+
 ``` bash
 copernicusmarine login
 # you will be prompted for your username and password and your credentials will be stored in a file at $HOME/.copernicusmarine/.copernicusmarine-credentials
 ```
 
+Alternativey, Copernicus Marine credentials can be set using environment variables `COPERNICUSMARINE_SERVICE_USERNAME` and `COPERNICUSMARINE_SERVICE_PASSWORD` - these will be used in preference to the credentials file.
 
 Now that everything is set up, the *PolarRoute-pipeline* can be used. Please refer to the [Using the pipeline](using.md) section of this documentation for details of how to operate the pipeline.
 

--- a/docs/setting-up.md
+++ b/docs/setting-up.md
@@ -40,16 +40,12 @@ echo verify:0 >> $HOME/.cdsapirc
 ```
 
 ### Copernicus Marine API
-The Copernicus API to is used to download up-to-date DUACS currents data. This service requires obtaining a USERNAME and PASSWORD for logging in. Once you have the username and password they can be stored separately to the pipeline in the user's `HOME` directory. You can register on the [Copernicus Marine API Registration](https://data.marine.copernicus.eu/register) page.
+The Copernicus API to is used to download up-to-date DUACS currents data. This service requires obtaining a USERNAME and PASSWORD for logging in. Once you have the username and password they can be stored separately to the pipeline in the user's `HOME` directory. You can register on the [Copernicus Marine API Registration](https://data.marine.copernicus.eu/register) page. Then, use the `copernicusmarine` command line tool to log in and set up your credentials file. First make sure that your python virtual environment is activated and you have installed the dependencies. Then:
 ``` bash
-mkdir -p $HOME/.copernicusmarine
-echo <your-unique-username> > $HOME/.copernicusmarine/user
-echo <your-unique-password> > $HOME/.copernicusmarine/password
+copernicusmarine login
+# you will be prompted for your username and password and your credentials will be stored in a file at $HOME/.copernicusmarine/.copernicusmarine-credentials
 ```
- - The above commands will create the required credentials files. If you wish to remove the details of these commands in your shell's history, you can perform the following:  
-   1. Logout *(this will flush your shell history to ~/.bash_history)*
-   1. Login
-   1. ` cat /dev/null > ~/.bash_history ` *(this will erase all of your bash history)*
+
 
 Now that everything is set up, the *PolarRoute-pipeline* can be used. Please refer to the [Using the pipeline](using.md) section of this documentation for details of how to operate the pipeline.
 

--- a/scripts/data_get_credentials.sh
+++ b/scripts/data_get_credentials.sh
@@ -5,9 +5,9 @@ set -e
 copernicus_credentials_dir="$HOME/.copernicusmarine"
 copernicus_credentials_file="$copernicus_credentials_dir/.copernicusmarine-credentials"
 
-# CopernicusMarine Credentials
-if [ -f "$copernicus_credentials_file" ]; then
-    echo "Using copernicusmarine credentials from $copernicus_credentials_file"
+# CopernicusMarine Credentials - use environment variables as priority, then copernicus credentials file format, fall back on old user and password files
+if [[ -n "$COPERNICUSMARINE_SERVICE_USERNAME" ]] && [[ -n "$COPERNICUSMARINE_SERVICE_PASSWORD" ]] || [ -f "$copernicus_credentials_file" ]; then
+    copernicusmarine login --check-credentials-valid
 elif [ -f "$copernicus_credentials_dir/user" ] && [ -f "$copernicus_credentials_dir/password" ]; then
     COPERNICUS_USER=$(< "${HOME}"/.copernicusmarine/user)
     COPERNICUS_PASSWORD=$(< "${HOME}"/.copernicusmarine/password)
@@ -15,9 +15,9 @@ elif [ -f "$copernicus_credentials_dir/user" ] && [ -f "$copernicus_credentials_
     copernicusmarine login \
     --username "$COPERNICUS_USER" \
     --password "$COPERNICUS_PASSWORD"
-
 else
-    echo "ERROR - No credentials found for copernicusmarine. Please log in using copernicusmarine login"
+    echo "ERROR - Username and password not found for copernicusmarine. Please log in using copernicusmarine login \
+        or set COPERNICUSMARINE_SERVICE_USERNAME and COPERNICUSMARINE_SERVICE_PASSWORD environment variables."
     exit 1
 fi
 

--- a/scripts/data_get_credentials.sh
+++ b/scripts/data_get_credentials.sh
@@ -2,13 +2,22 @@
 
 set -e
 
-# Get absolute path of pipeline directory
-pipeline_directory=$PIPELINE_DIRECTORY
-
-# Get user's credentials from their home directory
+copernicus_credentials_dir="$HOME/.copernicusmarine"
+copernicus_credentials_file="$copernicus_credentials_dir/.copernicusmarine-credentials"
 
 # CopernicusMarine Credentials
-echo COPERNICUS_USER='"'$(cat ${HOME}/.copernicusmarine/user)'"' > ${pipeline_directory}/credentials.env
-echo export COPERNICUS_USER >> ${pipeline_directory}/credentials.env
-echo COPERNICUS_PASSWORD='"'$(cat ${HOME}/.copernicusmarine/password)'"' >> ${pipeline_directory}/credentials.env
-echo export COPERNICUS_PASSWORD >> ${pipeline_directory}/credentials.env
+if [ -f "$copernicus_credentials_file" ]; then
+    echo "Using copernicusmarine credentials from $copernicus_credentials_file"
+elif [ -f "$copernicus_credentials_dir/user" ] && [ -f "$copernicus_credentials_dir/password" ]; then
+    COPERNICUS_USER=$(< "${HOME}"/.copernicusmarine/user)
+    COPERNICUS_PASSWORD=$(< "${HOME}"/.copernicusmarine/password)
+
+    copernicusmarine login \
+    --username "$COPERNICUS_USER" \
+    --password "$COPERNICUS_PASSWORD"
+
+else
+    echo "ERROR - No credentials found for copernicusmarine. Please log in using copernicusmarine login"
+    exit 1
+fi
+

--- a/scripts/data_retrieve_duacs.sh
+++ b/scripts/data_retrieve_duacs.sh
@@ -18,19 +18,11 @@ pipeline_directory=$PIPELINE_DIRECTORY
 # Determine the scripts directory
 scripts_directory=$pipeline_directory/scripts
 
-# Get hold of credentials if they exist
-if [ -f "$pipeline_directory/credentials.env" ]; then
-    source $pipeline_directory/credentials.env
-else
-    echo "ERROR - No Credentials Found"
-    exit 1
-fi
-
 # Where to put output files
 save_directory=$pipeline_directory/datastore/currents/duacs-nrt/global/
 
 # Create the output dir if it doesn't exist
-mkdir -p $save_directory
+mkdir -p "$save_directory"
 
 # Date for file formatting
 current_date=$(date --utc +%Y-%m-%d)
@@ -39,27 +31,25 @@ current_date=$(date --utc +%Y-%m-%d)
 for ((i = 0; i <= 3; i++)); do
     originaldate=$(date -d "$current_date -$i days" +%Y%m%d)
     date=$(date -d "$current_date -$i days" +%Y-%m-%d)
-    echo ${date}
+    echo "${date}"
     originalfilename="$save_directory/nrt_global_allsat_phy_l4_${originaldate}_${originaldate}.nc"
     filename="$save_directory/duacs_nrt_${date}.nc"
 
     # Only download if not present in the datastore
     if (test -f "$originalfilename") || (test -f "$filename"); then
-        echo "$(basename $filename) or $(basename $originalfilename) already exists!"
+        echo "$(basename "$filename") or $(basename "$originalfilename") already exists!"
     else
         # Download the data
         if ! copernicusmarine get \
             --dataset-id cmems_obs-sl_glo_phy-ssh_nrt_allsat-l4-duacs-0.125deg_P1D \
             --filter "*nrt_global_allsat_phy_l4_${originaldate}*" \
-            --output-directory $save_directory \
-            --username $COPERNICUS_USER \
-            --password $COPERNICUS_PASSWORD \
+            --output-directory "$save_directory" \
             --no-directories \
             --disable-progress-bar \
             --response-fields "file_path" \
             --log-level INFO
         then
-            echo DUACS global data file not found: ${filename}
+            echo DUACS global data file not found: "${filename}"
         fi
     fi
 done
@@ -67,9 +57,3 @@ done
 # Subset any downloaded original DUACS NetCDF files
 python $scripts_directory/data_subset_duacs.py
 
-# Remove credentials if they exist
-if [ -f "$pipeline_directory/credentials.env" ]; then
-    rm $pipeline_directory/credentials.env
-else
-    echo "No Credentials File to Remove"
-fi


### PR DESCRIPTION
Whilst setting up a fresh copy of the pipeline I noticed that copernicusmarine toolbox now favours the use of `copernicusmarine login` over `.copernicusmarine/{user,password}` files for auth.

It also uses environment variables as a priority over these creds files, which will simplify production deployments of the pipeline.

I've set this up so that env vars are taken as first priority, then the creds file format, then the older `user`/`password` files. If the user is using the latter, the script will now run the `copernicusmarine login` command (without user input) to validate creds and generate the file.

This also allows us to remove the funky "delete your bash history" section of the setup instructions.